### PR TITLE
Fix double move installing socket callback

### DIFF
--- a/rpm/0004-fix-double-move-callback.patch
+++ b/rpm/0004-fix-double-move-callback.patch
@@ -1,0 +1,13 @@
+diff --git a/platform/qt/src/mbgl/run_loop.cpp b/platform/qt/src/mbgl/run_loop.cpp
+index 6bd9cb035c5..aef0d2b98da 100644
+--- a/platform/qt/src/mbgl/run_loop.cpp
++++ b/platform/qt/src/mbgl/run_loop.cpp
+@@ -96,7 +96,7 @@ void RunLoop::addWatch(int fd, Event event, std::function<void(int, Event)>&& cb
+     if (event == Event::Read || event == Event::ReadWrite) {
+         auto notifier = std::make_unique<QSocketNotifier>(fd, QSocketNotifier::Read);
+         QObject::connect(notifier.get(), &QSocketNotifier::activated, impl.get(), &RunLoop::Impl::onReadEvent);
+-        impl->readPoll[fd] = WatchPair(std::move(notifier), std::move(cb));
++        impl->readPoll[fd] = WatchPair(std::move(notifier), cb);
+     }
+ 
+     if (event == Event::Write || event == Event::ReadWrite) {

--- a/rpm/maplibre-gl-native.spec
+++ b/rpm/maplibre-gl-native.spec
@@ -10,6 +10,7 @@ Source: %{name}-%{version}.tar.gz
 Patch1: 0001-Use-CURL-for-downloads.patch
 Patch2: 0002-Fixes-for-compilation-on-SFOS.patch
 Patch3: 0003-CURL_POLL_INOUT-action-handle-added-2365.patch
+Patch4: 0004-fix-double-move-callback.patch
 
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 


### PR DESCRIPTION
This avoids an empty callback being installed for a read/write event.